### PR TITLE
Run tests on more targets using cross and document platform support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,96 @@ matrix:
     - name: "Tools"
       install: true
       script: sh ci/tools.sh
-    - name: "x86_64-unknown-linux-gnu"
-      env: TARGET=x86_64-unknown-linux-gnu
-    - name: "i686-unknown-linux-gnu"
-      env: TARGET=i686-unknown-linux-gnu
+
+    # cross targets:
+    - name: "aarch64-linux-android"
+      env: TARGET=aarch64-linux-android CROSS=1
+    - name: "aarch64-unknown-linux-gnu"
+      env: TARGET=aarch64-unknown-linux-gnu CROSS=1
+    - name: "arm-linux-androideabi"
+      env: TARGET=arm-linux-androideabi CROSS=1
+    - name: "arm-unknown-linux-gnueabi"
+      env: TARGET=arm-unknown-linux-gnueabi CROSS=1
+    - name: "arm-unknown-linux-musleabi"
+      env: TARGET=arm-unknown-linux-musleabi CROSS=1
+    - name: "armv7-linux-androideabi"
+      env: TARGET=armv7-linux-androideabi CROSS=1
+    - name: "armv7-unknown-linux-gnueabihf"
+      env: TARGET=armv7-unknown-linux-gnueabihf CROSS=1
+    - name: "armv7-unknown-linux-musleabihf"
+      env: TARGET=armv7-unknown-linux-musleabihf CROSS=1
+    - name: "i586-unknown-linux-gnu"
+      env: TARGET=i586-unknown-linux-gnu CROSS=1
+      addons: &gcc_multilib
+        apt:
+          packages:
+            - gcc-multilib
+    - name: "i586-unknown-linux-musl"
+      env: TARGET=i586-unknown-linux-musl CROSS=1
+      addons: &gcc_multilib
+        apt:
+          packages:
+            - gcc-multilib
+
     - name: "i686-apple-darwin"
       env: TARGET=i686-apple-darwin
       os: osx
       osx_image: xcode10
+    - name: "i686-linux-android" 
+      env: TARGET=i686-linux-android CROSS=1
+    - name: "i686-pc-windows-gnu" 
+      env: TARGET=i686-pc-windows-gnu CROSS=1
+    - name: "i686-unknown-freebsd" 
+      env: TARGET=i686-unknown-freebsd NORUN=1 CROSS=1
+    - name: "i686-unknown-linux-gnu"
+      env: TARGET=i686-unknown-linux-gnu CROSS=1
+      addons: *gcc_multilib
+    - name: "i686-unknown-linux-musl"
+      env: TARGET=i686-unknown-linux-musl CROSS=1
+    - name: "mips-unknown-linux-gnu"
+      env: TARGET=mips-unknown-linux-gnu CROSS=1
+    - name: "mips64-unknown-linux-gnuabi64"
+      env: TARGET=mips64-unknown-linux-gnuabi64 CROSS=1
+    - name: "mips64el-unknown-linux-gnuabi64"
+      env: TARGET=mips64el-unknown-linux-gnuabi64 CROSS=1
+    - name: "mipsel-unknown-linux-gnu"
+      env: TARGET=mipsel-unknown-linux-gnu CROSS=1
+    - name: "powerpc-unknown-linux-gnu"
+      env: TARGET=powerpc-unknown-linux-gnu CROSS=1
+    - name: "powerpc64-unknown-linux-gnu"
+      env: TARGET=powerpc64-unknown-linux-gnu CROSS=1
+    - name: "powerpc64le-unknown-linux-gnu"
+      env: TARGET=powerpc64le-unknown-linux-gnu CROSS=1
+    - name: "s390x-unknown-linux-gnu"
+      env: TARGET=s390x-unknown-linux-gnu CROSS=1 NORUN=1
+    - name: "sparc64-unknown-linux-gnu"
+      env: TARGET=sparc64-unknown-linux-gnu CROSS=1 NORUN=1
     - name: "x86_64-apple-darwin"
       env: TARGET=x86_64-apple-darwin
       os: osx
       osx_image: xcode10
       install: true
+    - name: "x86_64-linux-android"
+      env: TARGET=x86_64-linux-android CROSS=1
+    - name: "x86_64-sun-solaris"
+      env: TARGET=x86_64-sun-solaris NORUN=1 CROSS=1
+    - name: "x86_64-unknown-freebsd"
+      env: TARGET=x86_64-unknown-freebsd NORUN=1 CROSS=1
+    - name: "x86_64-unknown-linux-gnu"
+      env: TARGET=x86_64-unknown-linux-gnu
+      install: true
+    - name: "x86_64-unknown-linux-musl"
+      env: TARGET=x86_64-unknown-linux-musl CROSS=1
+    - name: "x86_64-unknown-netbsd"
+      env: TARGET=x86_64-unknown-netbsd NORUN=1 CROSS=1
 
-install: travis_retry rustup target add $TARGET
+install:
+  - travis_retry rustup target add $TARGET
+  - |
+    if [ "$CROSS" = "1" ]; then
+        cargo install cross
+    fi
+
 script:
   - cargo generate-lockfile
   - sh ci/run.sh "${TARGET}"

--- a/README
+++ b/README
@@ -1,0 +1,79 @@
+[![Build Status](https://travis-ci.com/rust-lang/libtest.svg?branch=master)](https://travis-ci.com/rust-lang/libtest) [![Build Status](https://dev.azure.com/gonzalobg88/libtest/_apis/build/status/rust-lang.libtest?branchName=master)](https://dev.azure.com/gonzalobg88/libtest/_build/latest?definitionId=1&branchName=master) [![Latest Version]][crates.io] [![docs]][master_docs]
+
+libtest - Rust's built-in unit-testing and benchmarking framework
+===
+
+See [The Rust Programming Language chapter on
+Testing](https://doc.rust-lang.org/book/ch11-00-testing.html).
+
+## Platform support
+
+The following table describes the supported platforms: "build" shows whether the
+library compiles without issues for a given target, while "run" shows whether
+the full testsuite passes on the target.
+
+| Target                            | Build | Run |
+|-----------------------------------|-------|-----|
+| `aarch64-linux-android`           | ✓     | ✓   |
+| `aarch64-unknown-linux-gnu`       | ✓     | ✓   |
+| `arm-linux-androideabi`           | ✓     | ✓   |
+| `arm-unknown-linux-gnueabi`       | ✓     | ✓   |
+| `arm-unknown-linux-musleabi`      | ✓     | ✓   |
+| `armv7-linux-androideabi`         | ✓     | ✓   |
+| `armv7-unknown-linux-gnueabihf`   | ✓     | ✓   |
+| `armv7-unknown-linux-musleabihf`  | ✓     | ✓   |
+| `i586-unknown-linux-gnu`          | ✓     | ✓   |
+| `i586-unknown-linux-musl`         | ✓     | ✓   |
+| `i686-linux-android`              | ✓     | ✓   |
+| `i686-pc-windows-gnu`             | ✓     | ✓   |
+| `i686-apple-darwin`               | ✓     | ✓   |
+| `i686-unknown-freebsd`            | ✓     | ✗   |
+| `i686-unknown-linux-gnu`          | ✓     | ✓   |
+| `i686-unknown-linux-musl`         | ✓     | ✓   |
+| `mips-unknown-linux-gnu`          | ✓     | ✓   |
+| `mips64-unknown-linux-gnuabi64`   | ✓     | ✓   |
+| `mips64el-unknown-linux-gnuabi64` | ✓     | ✓   |
+| `mipsel-unknown-linux-gnu`        | ✓     | ✓   |
+| `powerpc-unknown-linux-gnu`       | ✓     | ✓   |
+| `powerpc64-unknown-linux-gnu`     | ✓     | ✓   |
+| `powerpc64le-unknown-linux-gnu`   | ✓     | ✓   |
+| `sparc64-unknown-linux-gnu`       | ✓     | ✗   |
+| `s390x-unknown-linux-gnu`         | ✓     | ✓   |
+| `x86_64-apple-darwin`             | ✓     | ✓   |
+| `x86_64-sun-solaris`              | ✓     | ✗   |
+| `x86_64-linux-android`            | ✓     | ✓   |
+| `x86_64-pc-windows-gnu`           | ✓     | ✓   |
+| `x86_64-pc-windows-msvc`          | ✓     | ✓   |
+| `x86_64-unknown-freebsd`          | ✓     | ✗   |
+| `x86_64-unknown-linux-gnu`        | ✓     | ✓   |
+| `x86_64-unknown-linux-musl`       | ✓     | ✓   |
+| `x86_64-unknown-netbsd`           | ✓     | ✗   |
+
+## License
+
+This project is licensed under either of
+
+* [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+  ([LICENSE-APACHE](LICENSE-APACHE))
+
+* [MIT License](http://opensource.org/licenses/MIT)
+  ([LICENSE-MIT](LICENSE-MIT))
+
+at your option.
+
+## Contributing
+
+We welcome all people who want to contribute.
+
+Contributions in any form (issues, pull requests, etc.) to this project
+must adhere to Rust's [Code of Conduct].
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in `libtest` by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.
+
+[Code of Conduct]: https://www.rust-lang.org/en-US/conduct.html
+[Latest Version]: https://img.shields.io/crates/v/libtest.svg
+[crates.io]: https://crates.io/crates/libtest
+[docs]: https://docs.rs/libtest/badge.svg
+[docs.rs]: https://docs.rs/libtest/

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -4,5 +4,15 @@ set -ex
 
 : "${TARGET?The TARGET environment variable must be set.}"
 
-cargo test -vv --all --target="${TARGET}"
-cargo test -vv --all --target="${TARGET}" --release
+CARGO="cargo"
+if [ "${CROSS}" = "1" ]; then
+    CARGO=cross
+fi
+
+CMD="test"
+if [ "${NORUN}" = "1" ]; then
+    CMD=build
+fi
+
+"${CARGO}" "${CMD}" -vv --all --target="${TARGET}"
+"${CARGO}" "${CMD}" -vv --all --target="${TARGET}" --release


### PR DESCRIPTION
This isn't a long term solution, but cross is really easy to set up and should prevent us from breaking most of the targets in which libtest is already running.