### PR TITLE
Improve output when `#[test]` returns an `Err(_)` value

### DIFF
--- a/libtest/lib.rs
+++ b/libtest/lib.rs
@@ -305,12 +305,14 @@ pub fn test_main_static(tests: &[&TestDescAndFn]) {
 /// and checks for a `0` result.
 pub fn assert_test_result<T: Termination>(result: T) {
     let code = result.report();
-    assert_eq!(
-        code, 0,
-        "the test returned a termination value with a non-zero status code ({}) \
-         which indicates a failure",
-        code
-    );
+    if code != 0 {
+        panic!(
+            "the test returned a termination value with a non-zero status code ({}) \
+                which indicates a failure (this most likely means your test returned \
+                an `Err(_)` value)",
+            code,
+        );
+    }
 }
 
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
Output before:

    ---- foo stdout ----
    Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
    thread 'foo' panicked at 'assertion failed: `(left == right)`
      left: `1`,
     right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', src/libtest/lib.rs:335:5

Output with this commit:

    ---- foo stdout ----
    Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
    thread 'foo' panicked at 'the test returned a termination value with a non-zero status code (1) which indicates a failure (this most likely means your test returned an `Err(_)`)', src/libtest/lib.rs:336:9

It's still by no means perfect. But it's already way better since
there is no strange left/right 0/1 output (I regularly got confused
by that output and searched for a failing `assert_eq` in my code)


---

(This PR was initially opened [here](https://github.com/rust-lang/rust/pull/59263), but while it was open, `libtest` was moved out of the compiler repo.)