### PR TITLE
Added very basic JUnit output

### DIFF
--- a/libtest/Cargo.toml
+++ b/libtest/Cargo.toml
@@ -18,3 +18,4 @@ crate-type = ["dylib", "rlib"]
 [dependencies]
 getopts = "0.2"
 term = "0.5"
+chrono = "0.4"

--- a/libtest/formatters/junit.rs
+++ b/libtest/formatters/junit.rs
@@ -1,0 +1,123 @@
+use super::*;
+use ::chrono::prelude::*;
+use chrono::SecondsFormat;
+
+pub(crate) struct JUnitFormatter<T> {
+    out: OutputLocation<T>,
+    results: Vec<(TestDesc, TestResult)>,
+}
+
+impl<T: Write> JUnitFormatter<T> {
+    pub fn new(out: OutputLocation<T>) -> Self {
+        Self {
+            out,
+            results: Vec::new(),
+        }
+    }
+
+    fn write_message(&mut self, s: &str) -> io::Result<()> {
+        assert!(!s.contains('\n'));
+
+        self.out.write_all(s.as_ref())?;
+        self.out.write_all(b"\n")
+    }
+}
+
+impl<T: Write> OutputFormatter for JUnitFormatter<T> {
+    fn write_run_start(&mut self, _test_count: usize) -> io::Result<()> {
+        self.write_message(&"<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+    }
+
+    fn write_test_start(&mut self, _desc: &TestDesc) -> io::Result<()> {
+        // We do not output anything on test start.
+        Ok(())
+    }
+
+    fn write_timeout(&mut self, _desc: &TestDesc) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn write_result(
+        &mut self,
+        desc: &TestDesc,
+        result: &TestResult,
+        _stdout: &[u8],
+    ) -> io::Result<()> {
+        self.results.push((desc.clone(), result.clone()));
+        Ok(())
+    }
+
+    fn write_run_finish(
+        &mut self,
+        state: &ConsoleTestState,
+    ) -> io::Result<bool> {
+        self.write_message("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")?;
+        self.write_message("<testsuites>")?;
+
+        // JUnit expects time in the ISO8601, which was proposed in RFC 3339.
+        let timestamp =
+            Local::now().to_rfc3339_opts(SecondsFormat::Secs, false);
+        let elapsed_time =
+            state.start_time.elapsed().as_millis() as f32 / 1000.0;
+        self.write_message(&*format!(
+            "<testsuite name=\"test\" package=\"test\" id=\"0\" \
+             hostname=\"localhost\" \
+             errors=\"0\" \
+             failures=\"{}\" \
+             tests=\"{}\" \
+             time=\"{}\" \
+             timestamp=\"{}\">",
+            state.failed, state.total, elapsed_time, timestamp
+        ))?;
+        for (desc, result) in std::mem::replace(&mut self.results, Vec::new())
+        {
+            match result {
+                TestResult::TrFailed => {
+                    self.write_message(&*format!(
+                        "<testcase classname=\"test.global\" \
+                         name=\"{}\" time=\"0\">",
+                        desc.name.as_slice()
+                    ))?;
+                    self.write_message("<failure type=\"assert\"/>")?;
+                    self.write_message("</testcase>")?;
+                }
+
+                TestResult::TrFailedMsg(ref m) => {
+                    self.write_message(&*format!(
+                        "<testcase classname=\"test.global\" \
+                         name=\"{}\" time=\"0\">",
+                        desc.name.as_slice()
+                    ))?;
+                    self.write_message(&*format!(
+                        "<failure message=\"{}\" type=\"assert\"/>",
+                        m
+                    ))?;
+                    self.write_message("</testcase>")?;
+                }
+
+                TestResult::TrBench(ref b) => {
+                    self.write_message(&*format!(
+                        "<testcase classname=\"test.global\" \
+                         name=\"{}\" time=\"{}\" />",
+                        desc.name.as_slice(),
+                        b.ns_iter_summ.sum
+                    ))?;
+                }
+
+                _ => {
+                    self.write_message(&*format!(
+                        "<testcase classname=\"test.global\" \
+                         name=\"{}\" time=\"0\"/>",
+                        desc.name.as_slice()
+                    ))?;
+                }
+            }
+        }
+        self.write_message("<system-out/>")?;
+        self.write_message("<system-err/>")?;
+        self.write_message("</testsuite>")?;
+        self.write_message("</testsuites>")?;
+
+        Ok(state.failed == 0)
+    }
+}

--- a/libtest/formatters/mod.rs
+++ b/libtest/formatters/mod.rs
@@ -1,10 +1,12 @@
 use super::*;
 
 mod json;
+mod junit;
 mod pretty;
 mod terse;
 
 pub(crate) use self::json::JsonFormatter;
+pub(crate) use self::junit::JUnitFormatter;
 pub(crate) use self::pretty::PrettyFormatter;
 pub(crate) use self::terse::TerseFormatter;
 


### PR DESCRIPTION
This PR adds a very basic JUnit formatter, and should probably not be merged without further discussion.

This output format is widely used, but sadly is not standardized.
The best summary I could find is was in Catch's [website](http://help.catchsoftware.com/display/ET/JUnit+Format).

Some talk points:
- Some data and attributes are currently stubbed, such as the test-suite and class names.
- It is assumed only one test suite exists. (I'm not sure this concept is relevant to libtest's tests).
- Tests are given the run time "0" as they are currently not measured by the framework (benchmarks are given real time).
- It seems as if std-out/err are owned by the test-suite as far as JUnit is concerned, which is not the case in libtest. Should we concat the output of the [Failing?] testcases?
- We should probably give command-line flags to set the test-suite name, or somehow infer it from cargo. (or both)
- The chrono crate is used to format the timestamp in ISO8601, but if the dependency is unwanted, I can always rewrite this one function.
- Ideally I would want to test this feature either by using the junitparser python package or by validating the output using a JUnit crate, but I'm not sure if that's the best solution. Maybe I should just compare it to a known good output.

Thoughts?
