### PR TITLE
redox: Use isatty for stdout_isatty

### DIFF
--- a/libtest/Cargo.toml
+++ b/libtest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Rust Project Developers"]
 name = "libtest"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2018"
 description = "Rust's built in unit-test and micro-benchmarking framework"
 license = "MIT/Apache-2.0"

--- a/libtest/lib.rs
+++ b/libtest/lib.rs
@@ -1031,15 +1031,14 @@ fn use_color(opts: &TestOpts) -> bool {
 
 #[cfg(any(
     target_os = "cloudabi",
-    target_os = "redox",
     all(target_arch = "wasm32", not(target_os = "emscripten")),
     all(target_vendor = "fortanix", target_env = "sgx")
 ))]
 fn stdout_isatty() -> bool {
-    // FIXME: Implement isatty on Redox and SGX
+    // FIXME: Implement isatty on SGX
     false
 }
-#[cfg(any(unix, target_os = "fuchsia"))]
+#[cfg(any(unix, target_os = "fuchsia", target_os = "redox"))]
 fn stdout_isatty() -> bool {
     unsafe { libc::isatty(libc::STDOUT_FILENO) != 0 }
 }


### PR DESCRIPTION
`libc:isatty` is now available on Redox, so it can be used instead of the stub. A new release of the crate would be good, so that this can be used in the `rust` repository